### PR TITLE
Fix GitHub link in footer

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -133,7 +133,7 @@ const Footer = () => (
           <img src={medium} className="medium" />
           Medium
         </a>
-        <a href="https://medium.com/the-ethereum-name-service">
+        <a href="https://github.com/ensdomains">
           <img src={github} className="github" />
           Github
         </a>


### PR DESCRIPTION
Was pointing to the Medium page instead of GitHub.

Note, #1 is a pull request that modifies the actual output of the rendered page. I believe this is the source file for that rendered output, and should fix it on all pages that use that footer.