### PR TITLE
Fix casing of valueProp import

### DIFF
--- a/src/components/pitch/Pitch.js
+++ b/src/components/pitch/Pitch.js
@@ -5,7 +5,7 @@ import secure from '../../assets/secure.svg'
 import distributed from '../../assets/distributed.svg'
 import { modulate } from '../../utils'
 import mq from '../../mediaQuery'
-import ValueProp from '../ValueProp/ValueProp'
+import ValueProp from '../valueProp/ValueProp'
 
 class ValueCard extends React.Component {
   render() {


### PR DESCRIPTION
This PR fixes the casing of the path to the `ValueProp` component, allowing the project to be built on a case-sensitive filesystem.