### PR TITLE
Add link to discuss

### DIFF
--- a/src/components/footer/Footer.js
+++ b/src/components/footer/Footer.js
@@ -119,6 +119,9 @@ const Footer = () => (
       <div className="footer-left">
         <p className="copyright">© True Names LTD</p>
         <a href="http://docs.ens.domains/">Documentation</a>
+        <a href="http://discuss.ens.domains">
+          discuss.ens.domains
+        </a>
         <a href="https://gitter.im/ethereum/go-ethereum/name-registry">
           Gitter
         </a>

--- a/src/components/team/team.json
+++ b/src/components/team/team.json
@@ -7,7 +7,7 @@
   },
   "brantly": {
     "fullName": "Brantly Millegan",
-    "title": "Developer Relations",
+    "title": "Director of Operations",
     "type": "hexagon",
     "link": "https://twitter.com/BrantlyMillegan"
   },


### PR DESCRIPTION
Addressing https://github.com/ensdomains/ens.domains/issues/39

As there is no logo for the discussion channel (and probably no one recognise that's the logo), I added to the left footer.

<img width="1229" alt="Screenshot 2019-11-18 at 11 51 14" src="https://user-images.githubusercontent.com/2630/69050775-9e44bb80-09fa-11ea-95bf-b4aff1252f03.png">

We would need more design input from Becca if we want to have link on the social sections where Medium/Twitter/GithHub links are